### PR TITLE
Remove unnecessary import to fix compile error

### DIFF
--- a/Keystore.d.ts
+++ b/Keystore.d.ts
@@ -1,5 +1,3 @@
-import crypto from "libp2p-crypto";
-
 declare module "orbit-db-keystore" {
     export class Keystore {
 


### PR DESCRIPTION
The current master version of these type definitions won't compile (using tsc v. 3.6.4).
The error:
```
node_modules/@types/orbit-db/Keystore.d.ts:3:16 - error TS2665: Invalid module name in augmentation. Module 'orbit-db-keystore' resolves to an untyped module at 'node_modules/orbit-db-keystore/src/keystore.js', which cannot be augmented.

3 declare module "orbit-db-keystore" {
                 ~~~~~~~~~~~~~~~~~~~
```
The reason being, the import makes TypeScript treat this file as an augmentation.
I fixed the issue by simply removing the import on top, as it also seemed unnecessary.