### PR TITLE
fix: OrbitDB.createInstance(ipfs, [options]) returns a Promise

### DIFF
--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -45,7 +45,7 @@ declare module 'orbit-db' {
             keystore?: Keystore,
             cache: Cache,
             identity: Identity
-        }): OrbitDB
+        }): Promise<OrbitDB>
 
         create(name: string, type: string, options?: ICreateOptions): Promise<Store>;
 


### PR DESCRIPTION
Hi,

According to the documentation, the method `OrbitDB.createInstance` returns a `Promise<OrbitDB>`, c.f. https://github.com/orbitdb/orbit-db/blob/master/API.md#createinstanceipfs-options

```typescript
const orbitdb = await OrbitDB.createInstance(ipfs)
```

The purpose of the pull request is to add it.

Best regards