### PR TITLE
Make individual createInstance() options optional parameters

### DIFF
--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -40,11 +40,11 @@ declare module 'orbit-db' {
          * </ul>
          */
         static createInstance(ipfs: IPFS, options?: {
-            directory: string,
+            directory?: string,
             peerId?: string,
             keystore?: Keystore,
-            cache: Cache,
-            identity: Identity
+            cache?: Cache,
+            identity?: Identity
         }): OrbitDB
 
         create(name: string, type: string, options?: ICreateOptions): Promise<Store>;


### PR DESCRIPTION
The function OrbitDB.createInstance() takes an optional parameter `options`, however some of the individual attributes inside the `options` object are not marked as optional/nullable.
This means that you are forced to include all these attributes whenever you pass an `options` object to createInstance().

As the actual JS library, OrbitDB, has no such requirement, I made them all optional which should fix the issue.
I hope you'll consider accepting this pull request.