### PR TITLE
Fix Feed and Event store return types

### DIFF
--- a/EventStore.d.ts
+++ b/EventStore.d.ts
@@ -3,7 +3,7 @@ declare module "orbit-db-eventstore" {
 
     export class EventStore<T> extends Store {
         add(data: any): Promise<string>;
-        get(hash: string): T;
+        get(hash: string): LogEntry<T>;
 
         iterator(options?: { 
             gt?: string,
@@ -14,8 +14,8 @@ declare module "orbit-db-eventstore" {
             reverse?: boolean 
         }): {
             [Symbol.iterator](),
-            next(): { value: T, done: boolean },
-            collect(): { payload: { value: T, done: boolean }}[]
+            next(): { value: LogEntry<T>, done: boolean },
+            collect(): LogEntry<T>[]
         };
     }
 }

--- a/FeedStore.d.ts
+++ b/FeedStore.d.ts
@@ -1,9 +1,10 @@
+declare type LogEntry<T> = import('./LogEntry').LogEntry<T>;
 declare module "orbit-db-feedstore" {
     import { Store } from "orbit-db-store";
 
     export class FeedStore<T> extends Store {
         add(data: any): Promise<string>;
-        get(hash: string): T;
+        get(hash: string): LogEntry<T>
 
         remove(hash: string): Promise<string>;
 
@@ -16,8 +17,8 @@ declare module "orbit-db-feedstore" {
             reverse?: boolean 
         }): {
             [Symbol.iterator](),
-            next(): { value: T, done: boolean },
-            collect(): { payload: { value: T, done: boolean }}[]
+            next(): { value: LogEntry<T>, done: boolean },
+            collect(): LogEntry<T>[]
         };
     }
 }

--- a/FeedStore.d.ts
+++ b/FeedStore.d.ts
@@ -1,4 +1,3 @@
-declare type LogEntry<T> = import('./LogEntry').LogEntry<T>;
 declare module "orbit-db-feedstore" {
     import { Store } from "orbit-db-store";
 

--- a/LogEntry.d.ts
+++ b/LogEntry.d.ts
@@ -8,7 +8,7 @@ interface LamportClockJson {
     id: 'string',
     time: number
 }
-export interface LogEntry<T>{
+interface LogEntry<T>{
     hash: string,
     id: string,
     payload: { op?: string, key?: string, value: T},

--- a/LogEntry.ts
+++ b/LogEntry.ts
@@ -1,0 +1,21 @@
+interface IdentityJson {
+    id: string,
+    publicKey: string,
+    signatures: {id: string, publicKey: string},
+    type: string
+}
+interface LamportClockJson {
+    id: 'string',
+    time: number
+}
+export interface LogEntry<T>{
+    hash: string,
+    id: string,
+    payload: { op?: string, key?: string, value: T},
+    next: string[], // Hashes of parents
+    v: number, // Format, can be 0 or 1
+    clock: LamportClockJson,
+    key: string,
+    identity: IdentityJson,
+    sig: string
+}

--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="./DBOptions.d.ts" />
-
+/// <reference path="./LogEntry.d.ts" />
 declare module 'orbit-db' {
     import { Store } from "orbit-db-store";
     import { KeyValueStore } from "orbit-db-kvstore";


### PR DESCRIPTION
`EventStore` and `FeedStore.get()` methods have return types that are different from the other store types.
Instead of just returning the value of the entry, of type `T`, they return a much larger object that roughly corresponds to a representation of an IPFS-log Entry object (https://github.com/orbitdb/ipfs-log/blob/master/src/entry.js), although it's not an instance of it (I think?).
This object contains the actual value, under .payload.value.

The way the types are currently defined is wrong and it's not possible to properly use event and feed stores.

Thus I have created a fix for this.
The get() function actually returns this kind of object:
```
{
  hash: 'zdpuAkYkEV66tGZBmkCTm9SkjpXLdnJf6izs6mRL83rMwi8Zo',
  id: '/orbitdb/zdpuAxjkWJXG2YJrNhFGSZmWFnwVDvVTpr9aFpVYt3ncvxaL4/1571260621998',
  payload: { op: 'ADD', key: null, value: '1571260621998' },
  next: [],
  v: 1,
  clock: LamportClock {
    id: '041cf339c51f5aea16244f2b0e684b743f90c28b0233125f351310e636c25bd5a89f4abc1d6d83f86f128039bd8a1c31f1a1548339a01a6fde98f134aa085f7483',
    time: 1
  },
  key: '041cf339c51f5aea16244f2b0e684b743f90c28b0233125f351310e636c25bd5a89f4abc1d6d83f86f128039bd8a1c31f1a1548339a01a6fde98f134aa085f7483',
  identity: {
    id: '02e9cde6c4a96bd124e4a28d7f52d2cd14cfadd83b27d6ddcee5633467e27de4db',
    publicKey: '041cf339c51f5aea16244f2b0e684b743f90c28b0233125f351310e636c25bd5a89f4abc1d6d83f86f128039bd8a1c31f1a1548339a01a6fde98f134aa085f7483',
    signatures: {
      id: '304402204d4ec0f5d3f08081fd23addec3b8be868badabc24984544eb08d6d21bc0b209102201d8d0a15d3dd8d4b8d16786e72f82dbf293fd689d96fffd9b4980e31fbb004aa',
      publicKey: '304402204160da924c6b00c479691c283bfc4b2ee3e142b8b7b3e6930d8ac7248574b17f022046c93bfec078bfc4c442e20848403239076fc112301191a7ee39a4ed81d42ffb'
    },
    type: 'orbitdb'
  },
  sig: '3044022047588d327154b3ef9202d41bc0622bac0718d9728319086c5f4190764c0c044702207d2786b7ba62a400a28fb9f3fde89af08ed0430bc8a67fe12620f4d694a980cf'
}
```
I created an interface LogEntry<T> which represents the object in question. I then added this object to the type definitions for the two stores.
It compiles and seems to work correctly, I am now able to add entries and read them, as well as access their properties without getting a compiler error like before.

I also modified the return types of the two `iterator()` functions, `next()` and `collect()`, which had the same problem, again based on what they actually return, and all appears to work correctly.