### PR TITLE
fix: error TS1086: An accessor cannot be declared in an ambient context.

### DIFF
--- a/Identity.d.ts
+++ b/Identity.d.ts
@@ -8,11 +8,11 @@ declare module "orbit-db-identity-provider" {
         private _type: string
         private _provider: string
 
-        get id(): string
-        get publicKey(): string
-        get signatures(): {id:string, publicKey:string}
-        get type(): string
-        get provider(): string
+        readonly id: string
+        readonly publicKey: string
+        readonly signatures: { id: string, publicKey: string }
+        readonly type: string
+        readonly provider: string
 
         toJSON(): {
             id:string,


### PR DESCRIPTION
Hi,

In the file `Identity.d.ts`, the usage of getter (eg. `get id(): string`) is not allowed by Typescript, c.f. error TS1086: An accessor cannot be declared in an ambient context.

I replaced the accessors by read-only properties (eg. `readonly id: string`).

Best regards