### PR TITLE
feat: add TStoreType to improve auto completion

### DIFF
--- a/DBOptions.d.ts
+++ b/DBOptions.d.ts
@@ -1,3 +1,4 @@
+
 interface ICreateOptions {
     /**
      * The directory where data will be stored (Default: uses directory option passed to OrbitDB constructor or ./orbitdb if none was provided).
@@ -45,7 +46,7 @@ interface IOpenOptions {
      * Otherwise it's used to validate the manifest.
      * You ony need to set this if using OrbitDB#open
      */
-    type?: string;
+    type?: TStoreType;
 
     /**
      * Overwrite an existing database (Default: false)
@@ -59,5 +60,7 @@ interface IOpenOptions {
 }
 
 interface IStoreOptions extends ICreateOptions, IOpenOptions { }
+
+type TStoreType ='log' | 'feed' | 'keyvalue' | 'docs' | 'counter' | string;
 
 //export {ICreateOptions, IOpenOptions, IStoreOptions};

--- a/DBOptions.d.ts
+++ b/DBOptions.d.ts
@@ -61,6 +61,7 @@ interface IOpenOptions {
 
 interface IStoreOptions extends ICreateOptions, IOpenOptions { }
 
-type TStoreType ='log' | 'feed' | 'keyvalue' | 'docs' | 'counter' | string;
+// c.f. https://github.com/orbitdb/orbit-db/blob/master/API.md#orbitdbdatabasetypes
+type TStoreType = 'counter' | 'eventlog' | 'feed' | 'docstore' | 'keyvalue' | string;
 
 //export {ICreateOptions, IOpenOptions, IStoreOptions};

--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -47,7 +47,7 @@ declare module 'orbit-db' {
             identity?: Identity
         }): Promise<OrbitDB>
 
-        create(name: string, type: string, options?: ICreateOptions): Promise<Store>;
+        create(name: string, type: TStoreType, options?: ICreateOptions): Promise<Store>;
 
         open(address: string, options?: IOpenOptions): Promise<Store>;
 
@@ -63,7 +63,7 @@ declare module 'orbit-db' {
         docs<T>(address: string, options?: IStoreOptions): Promise<DocumentStore<T>>;
         docstore<T>(address: string, options?: IStoreOptions): Promise<DocumentStore<T>>;
 
-        static isValidType(type: string);
+        static isValidType(type: TStoreType);
         static addDatabaseType(type: string, store: Store);
         static getDatabaseTypes(): {};
         static isValidAddress(address: string): boolean;


### PR DESCRIPTION
Hi,

In order to improve auto completion in IDEs, I added the built-in store types:

```typescript
type TStoreType = 'counter' | 'eventlog' | 'feed' | 'docstore' | 'keyvalue' | string;
```

I replaced the type string by TStoreType for

- OrbitDB.create
- OrbitDB.isValidType
- IOpenOptions.type

Best regards