### PR TITLE
Fix: wrong addDatabaseType() signature

### DIFF
--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -64,7 +64,7 @@ declare module 'orbit-db' {
         docstore<T>(address: string, options?: IStoreOptions): Promise<DocumentStore<T>>;
 
         static isValidType(type: string);
-        static addDatabaseType(type: string, store: Store);
+        static addDatabaseType(type: string, store: typeof Store);
         static getDatabaseTypes(): {};
         static isValidAddress(address: string): boolean;
     }


### PR DESCRIPTION
The static method `OrbitDB.addDatabaseType(type: string, store: Store)` has the wrong type signature and that makes it impossible to use, as it will always cause a compile error even when used correctly:

```
src/index.ts:30:38 - error TS2345: Argument of type 'typeof Store' is not assignable to parameter of type 'Store'.
  Type 'typeof Store' is missing the following properties from type 'Store': address, all, type, key, and 6 more.

30     OrbitDB.addDatabaseType('store', Store)
                                        ~~~~~

  src/index.ts:30:38
    30     OrbitDB.addDatabaseType('store', Store)
                                            ~~~~~
    Did you mean to use 'new' with this expression?


Found 1 error.
```
The issue is very subtle, but `store: Store` actually indicates that the function accepts an **instance** of `Store`. In reality we want the function to take a class, whether that's `Store`, or something that inherits from it.
I fixed it by changing the signature to
```JS
static addDatabaseType(type: string, store: typeof Store);
```