### PR TITLE
Fix: default export all Store types

### DIFF
--- a/CounterStore.d.ts
+++ b/CounterStore.d.ts
@@ -1,10 +1,9 @@
 declare module "orbit-db-counterstore" {
     import Store from "orbit-db-store";
 
-    class CounterStore extends Store {
+    export default class CounterStore extends Store {
         value: number;
         
         inc(value?: number): Promise<string>;
     }
-    export = CounterStore
 }

--- a/CounterStore.d.ts
+++ b/CounterStore.d.ts
@@ -1,9 +1,10 @@
 declare module "orbit-db-counterstore" {
-    import { Store } from "orbit-db-store";
+    import Store from "orbit-db-store";
 
-    export class CounterStore extends Store {
+    class CounterStore extends Store {
         value: number;
         
         inc(value?: number): Promise<string>;
     }
+    export = CounterStore
 }

--- a/DocumentStore.d.ts
+++ b/DocumentStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-docstore" {
-    import { Store } from "orbit-db-store";
+    import Store from "orbit-db-store";
 
-    export class DocumentStore<T> extends Store {
+    class DocumentStore<T> extends Store {
 
         put(key: any, value: any): Promise<string>;
         get(key: any): T[];
@@ -11,4 +11,5 @@ declare module "orbit-db-docstore" {
         del(key: any): Promise<string>;
         
     }
+    export = DocumentStore
 }

--- a/DocumentStore.d.ts
+++ b/DocumentStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-docstore" {
     import Store from "orbit-db-store";
 
-    class DocumentStore<T> extends Store {
+    export default class DocumentStore<T> extends Store {
 
         put(key: any, value: any): Promise<string>;
         get(key: any): T[];
@@ -11,5 +11,4 @@ declare module "orbit-db-docstore" {
         del(key: any): Promise<string>;
         
     }
-    export = DocumentStore
 }

--- a/EventStore.d.ts
+++ b/EventStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-eventstore" {
     import Store from "orbit-db-store";
 
-    class EventStore<T> extends Store {
+    export default class EventStore<T> extends Store {
         add(data: any): Promise<string>;
         get(hash: string): LogEntry<T>;
 
@@ -18,5 +18,4 @@ declare module "orbit-db-eventstore" {
             collect(): LogEntry<T>[]
         };
     }
-    export = EventStore
 }

--- a/EventStore.d.ts
+++ b/EventStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-eventstore" {
-    import { Store } from "orbit-db-store";
+    import Store from "orbit-db-store";
 
-    export class EventStore<T> extends Store {
+    class EventStore<T> extends Store {
         add(data: any): Promise<string>;
         get(hash: string): LogEntry<T>;
 
@@ -18,4 +18,5 @@ declare module "orbit-db-eventstore" {
             collect(): LogEntry<T>[]
         };
     }
+    export = EventStore
 }

--- a/FeedStore.d.ts
+++ b/FeedStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-feedstore" {
     import Store from "orbit-db-store";
 
-    class FeedStore<T> extends Store {
+    export default class FeedStore<T> extends Store {
         add(data: any): Promise<string>;
         get(hash: string): LogEntry<T>
 
@@ -20,5 +20,4 @@ declare module "orbit-db-feedstore" {
             collect(): LogEntry<T>[]
         };
     }
-    export = FeedStore
 }

--- a/FeedStore.d.ts
+++ b/FeedStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-feedstore" {
-    import { Store } from "orbit-db-store";
+    import Store from "orbit-db-store";
 
-    export class FeedStore<T> extends Store {
+    class FeedStore<T> extends Store {
         add(data: any): Promise<string>;
         get(hash: string): LogEntry<T>
 
@@ -20,4 +20,5 @@ declare module "orbit-db-feedstore" {
             collect(): LogEntry<T>[]
         };
     }
+    export = FeedStore
 }

--- a/IReplicationStatus.d.ts
+++ b/IReplicationStatus.d.ts
@@ -1,0 +1,6 @@
+interface IReplicationStatus {
+    buffered: number;
+    queued: number;
+    progress: number;
+    max: number;
+}

--- a/KeyValueStore.d.ts
+++ b/KeyValueStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-kvstore" {
-    import { Store } from "orbit-db-store";
+    import Store from "orbit-db-store";
 
-    export class KeyValueStore<V> extends Store {
+    class KeyValueStore<V> extends Store {
 
         put(key: string, value: V): Promise<void>;
         set(key: string, value: V): Promise<void>;
@@ -9,4 +9,5 @@ declare module "orbit-db-kvstore" {
         get(key: string): V;
 
     }
+    export = KeyValueStore
 }

--- a/KeyValueStore.d.ts
+++ b/KeyValueStore.d.ts
@@ -1,7 +1,7 @@
 declare module "orbit-db-kvstore" {
     import Store from "orbit-db-store";
 
-    class KeyValueStore<V> extends Store {
+    export default class KeyValueStore<V> extends Store {
 
         put(key: string, value: V): Promise<void>;
         set(key: string, value: V): Promise<void>;
@@ -9,5 +9,4 @@ declare module "orbit-db-kvstore" {
         get(key: string): V;
 
     }
-    export = KeyValueStore
 }

--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -1,12 +1,12 @@
 /// <reference path="./DBOptions.d.ts" />
 /// <reference path="./LogEntry.d.ts" />
 declare module 'orbit-db' {
-    import { Store } from "orbit-db-store";
-    import { KeyValueStore } from "orbit-db-kvstore";
-    import { FeedStore } from "orbit-db-feedstore";
-    import { EventStore } from "orbit-db-eventstore";
-    import { DocumentStore } from "orbit-db-docstore";
-    import { CounterStore } from "orbit-db-counterstore";
+    import Store from "orbit-db-store";
+    import KeyValueStore from "orbit-db-kvstore";
+    import FeedStore from "orbit-db-feedstore";
+    import EventStore from "orbit-db-eventstore";
+    import DocumentStore from "orbit-db-docstore";
+    import CounterStore from "orbit-db-counterstore";
     import { Keystore } from "orbit-db-keystore";
     import { Cache } from "orbit-db-cache";
     import { Identity } from "orbit-db-identity-provider";

--- a/Store.d.ts
+++ b/Store.d.ts
@@ -5,7 +5,7 @@ declare module "orbit-db-store" {
     import { EventEmitter } from 'events';
     import * as elliptic from "elliptic";
 
-    class Store {
+    export default class Store {
 
         /**
          * The identity is used to sign the database entries.
@@ -50,5 +50,4 @@ declare module "orbit-db-store" {
         protected _addOperation(data: any);
     }
 
-    export = Store
 }

--- a/Store.d.ts
+++ b/Store.d.ts
@@ -5,7 +5,7 @@ declare module "orbit-db-store" {
     import { EventEmitter } from 'events';
     import * as elliptic from "elliptic";
 
-    export class Store {
+    class Store {
 
         /**
          * The identity is used to sign the database entries.
@@ -50,10 +50,11 @@ declare module "orbit-db-store" {
         protected _addOperation(data: any);
     }
 
-    export interface IReplicationStatus {
+    interface IReplicationStatus {
         buffered: number;
         queued: number;
         progress: number;
         max: number;
     }
+    export = Store
 }

--- a/Store.d.ts
+++ b/Store.d.ts
@@ -50,11 +50,5 @@ declare module "orbit-db-store" {
         protected _addOperation(data: any);
     }
 
-    interface IReplicationStatus {
-        buffered: number;
-        queued: number;
-        progress: number;
-        max: number;
-    }
     export = Store
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,3 +8,5 @@
 /// <reference path="./Identity.d.ts"      />
 /// <reference path="./Keystore.d.ts"      />
 /// <reference path="./DBOptions.d.ts"     />
+/// <reference path="./LogEntry.d.ts" />
+/// <reference path="./IReplicationStatus.d.ts" />


### PR DESCRIPTION
In the OrbitDB JS source code all stores are default exports (https://github.com/orbitdb/orbit-db-store/blob/master/src/Store.js#L512), however without this patch the type definitions use named exports.

As a result it's impossible to import them and use them in Typescript; importing `Store` for example wouldn't cause a compile error, but it does break at runtime since  `Store` remains `undefined` after being imported.

This is not an issue when using OrbitDB normally because you don't have to import any of the `Store` subclasses.
However if you want to make your own store by extending `Store`, you're met with a runtime error when writing `class X extends Store {}`, the latter being `undefined`

This pull request fixes that.

I also had to move an interface in its own file, because it was in the Store.d.ts file, which uses default export now and can't have another export in it.