### PR TITLE
Fix: DB and Store creation options

### DIFF
--- a/DBOptions.d.ts
+++ b/DBOptions.d.ts
@@ -4,15 +4,17 @@ interface ICreateOptions {
      * The directory where data will be stored (Default: uses directory option passed to OrbitDB constructor or ./orbitdb if none was provided).
      */
     directory?: string;
-
-    /**
-     * An array of hex encoded public keys which are used to set write access to the database.
-     * ["*"] can be passed in to give write access to everyone.
-     * See the GETTING STARTED guide for more info.
-     * (Default: uses the OrbitDB instance key orbitdb.key, which would give write access only to yourself)
-     */
-    write?: string[];
-
+    
+    accessController?: { 
+        /**
+         * An array of hex encoded public keys which are used to set write access to the database.
+         * ["*"] can be passed in to give write access to everyone.
+         * See the GETTING STARTED guide for more info.
+         * (Default: uses the OrbitDB instance key orbitdb.key, which would give write access only to yourself)
+         */
+        write?: string[] 
+    };
+    
     /**
      * Overwrite an existing database (Default: false)
      */
@@ -59,7 +61,9 @@ interface IOpenOptions {
     replicate?: boolean;
 }
 
-interface IStoreOptions extends ICreateOptions, IOpenOptions { }
+interface IStoreOptions extends ICreateOptions, IOpenOptions {
+    Index?: any
+}
 
 // c.f. https://github.com/orbitdb/orbit-db/blob/master/API.md#orbitdbdatabasetypes
 type TStoreType = 'counter' | 'eventlog' | 'feed' | 'docstore' | 'keyvalue' | string;

--- a/DBOptions.d.ts
+++ b/DBOptions.d.ts
@@ -12,7 +12,12 @@ interface ICreateOptions {
          * See the GETTING STARTED guide for more info.
          * (Default: uses the OrbitDB instance key orbitdb.key, which would give write access only to yourself)
          */
-        write?: string[] 
+        write?: string[]
+        
+        /**
+         * Name of custom AccessController
+         */
+        type?: string 
     };
     
     /**


### PR DESCRIPTION
Database creation options now have an accessController parameter which contains write[], I have fixed this definition to reflect that.
https://github.com/orbitdb/orbit-db/blob/master/GUIDE.md#access-control
I've also added the Index property to the Store options, which was missing