### PR TITLE
Fix Store iterator typings

### DIFF
--- a/EventStore.d.ts
+++ b/EventStore.d.ts
@@ -13,7 +13,7 @@ declare module "orbit-db-eventstore" {
             limit?: number, 
             reverse?: boolean 
         }): {
-            [Symbol.iterator](),
+            [Symbol.iterator](): Iterator<LogEntry<T>>,
             next(): { value: LogEntry<T>, done: boolean },
             collect(): LogEntry<T>[]
         };

--- a/FeedStore.d.ts
+++ b/FeedStore.d.ts
@@ -15,7 +15,7 @@ declare module "orbit-db-feedstore" {
             limit?: number, 
             reverse?: boolean 
         }): {
-            [Symbol.iterator](),
+            [Symbol.iterator](): Iterator<LogEntry<T>>,
             next(): { value: LogEntry<T>, done: boolean },
             collect(): LogEntry<T>[]
         };


### PR DESCRIPTION
Fix iterator typings beeing `any`.

Before, types were set only when using `collect()`.

Result:
![image](https://user-images.githubusercontent.com/26366184/77086350-f23fcb00-6a01-11ea-975a-4b3937585343.png)

```ts
const kvStore = await orbitDb.log<string>('logtest', { create: true })

await kvStore.add('test1')
await kvStore.add('test2')
await kvStore.add('test3')

for (const anEntry of kvStore.iterator({ limit: -1, reverse: true })) {
  const value = anEntry.payload.value
  if (value.endsWith('2'))
    console.log(anEntry.payload.value)
}
```