### PR TITLE
[fix] KeyValueStore should return string for put/set/del operations instead of void

### DIFF
--- a/KeyValueStore.d.ts
+++ b/KeyValueStore.d.ts
@@ -4,9 +4,9 @@ declare module "orbit-db-kvstore" {
     export default class KeyValueStore<V> extends Store {
         get(key: string): V;
 
-        put(key: string, value: V, options?: {}): Promise<void>;
-        set(key: string, value: V, options?: {}): Promise<void>;
+        put(key: string, value: V, options?: {}): Promise<string>;
+        set(key: string, value: V, options?: {}): Promise<string>;
         
-        del(key: string, options?: {}): Promise<void>;
+        del(key: string, options?: {}): Promise<string>;
     }
 }


### PR DESCRIPTION
As per the [documentation](https://github.com/haadcode/orbit-db/blob/main/API.md#putkey-value) the put/set/del operations of the KeyValueStore, should return a string containing the multihash of the entry.

But, in this types package, those operations return `void`. 

This pull request fixes those types.