### PR TITLE
Add identity attribute type to OrbitDB class

### DIFF
--- a/OrbitDB.d.ts
+++ b/OrbitDB.d.ts
@@ -18,6 +18,7 @@ declare module 'orbit-db' {
         _ipfs: IPFS;
 
         id: string;
+        identity: Identity;
         stores: any;
         directory: string;
         keystore: Keystore;


### PR DESCRIPTION
While working on a reimplementation of the OrbitDB HTTP API, I came across the missing attribute for the identity.

My guess is that the identity attribute was simply forgotten since it has been implemented in the OrbitDB API. 

